### PR TITLE
Improve performance of wheel picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the **FlexColorPicker** package will be documented in this file.
 
+## [2.1.2] - July 15, 2021
+* **Improvement:** Improved performance by splitting wheel painting into
+  multiple painters and introducing `RepaintBoundary` widgets around
+  expensive painters to avoid unnecessary repaints.
+
 ## [2.1.1] - July 2, 2021
 * Documentation fix.
 

--- a/lib/src/color_wheel_picker.dart
+++ b/lib/src/color_wheel_picker.dart
@@ -318,7 +318,7 @@ class _ColorWheelPickerState extends State<ColorWheelPicker> {
                       colorValue: colorValue,
                       hasBorder: widget.hasBorder,
                       borderColor:
-                        widget.borderColor ?? Theme.of(context).dividerColor,
+                          widget.borderColor ?? Theme.of(context).dividerColor,
                       wheelWidth: widget.wheelWidth,
                     ),
                   ),
@@ -334,7 +334,7 @@ class _ColorWheelPickerState extends State<ColorWheelPicker> {
                     painter: _WheelPainter(
                       hasBorder: widget.hasBorder,
                       borderColor:
-                        widget.borderColor ?? Theme.of(context).dividerColor,
+                          widget.borderColor ?? Theme.of(context).dividerColor,
                       wheelWidth: widget.wheelWidth,
                       ticks: 360,
                     ),
@@ -388,7 +388,7 @@ class _ShadePainter extends CustomPainter {
     final Rect _rectBox = Rect.fromLTWH(_center.dx - _squareRadius,
         _center.dy - _squareRadius, _squareRadius * 2, _squareRadius * 2);
     final RRect rRect =
-    RRect.fromRectAndRadius(_rectBox, const Radius.circular(4));
+        RRect.fromRectAndRadius(_rectBox, const Radius.circular(4));
 
     final Shader _horizontal = LinearGradient(
       colors: <Color>[
@@ -425,13 +425,12 @@ class _ShadePainter extends CustomPainter {
 
   @override
   bool shouldRepaint(_ShadePainter oldDelegate) {
-    return
-      oldDelegate.hasBorder != hasBorder ||
-          oldDelegate.borderColor != borderColor ||
-          oldDelegate.wheelWidth != wheelWidth ||
-          oldDelegate.colorHue != colorHue ||
-          oldDelegate.colorSaturation != colorSaturation ||
-          oldDelegate.colorValue != colorValue;
+    return oldDelegate.hasBorder != hasBorder ||
+        oldDelegate.borderColor != borderColor ||
+        oldDelegate.wheelWidth != wheelWidth ||
+        oldDelegate.colorHue != colorHue ||
+        oldDelegate.colorSaturation != colorSaturation ||
+        oldDelegate.colorValue != colorValue;
   }
 }
 
@@ -464,7 +463,7 @@ class _WheelPainter extends CustomPainter {
     // creating an ellipse, so we/ keep it as a circle by always using the
     // shortest side in the surrounding rectangle to make a square.
     final double _shortestRectSide =
-    math.min(size.width, size.height).toDouble();
+        math.min(size.width, size.height).toDouble();
 
     final Rect rectCircle = Rect.fromCenter(
         center: _center,
@@ -510,11 +509,10 @@ class _WheelPainter extends CustomPainter {
 
   @override
   bool shouldRepaint(_WheelPainter oldDelegate) {
-    return
-      oldDelegate.hasBorder != hasBorder ||
-          oldDelegate.borderColor != borderColor ||
-          oldDelegate.wheelWidth != wheelWidth ||
-          oldDelegate.ticks != ticks;
+    return oldDelegate.hasBorder != hasBorder ||
+        oldDelegate.borderColor != borderColor ||
+        oldDelegate.wheelWidth != wheelWidth ||
+        oldDelegate.ticks != ticks;
   }
 }
 
@@ -555,9 +553,9 @@ class _ShadeThumbPainter extends CustomPainter {
 
     // Define the selection thumb position on the square
     final double _paletteX =
-    _Wheel.saturationToVector(colorSaturation, _squareRadius, _center.dx);
+        _Wheel.saturationToVector(colorSaturation, _squareRadius, _center.dx);
     final double _paletteY =
-    _Wheel.valueToVector(colorValue, _squareRadius, _center.dy);
+        _Wheel.valueToVector(colorValue, _squareRadius, _center.dy);
     final Offset paletteVector = Offset(_paletteX, _paletteY);
 
     // Draw the wider black circle first, then draw the smaller white circle
@@ -569,10 +567,9 @@ class _ShadeThumbPainter extends CustomPainter {
 
   @override
   bool shouldRepaint(_ShadeThumbPainter oldDelegate) {
-    return
-      oldDelegate.wheelWidth != wheelWidth ||
-          oldDelegate.colorSaturation != colorSaturation ||
-          oldDelegate.colorValue != colorValue;
+    return oldDelegate.wheelWidth != wheelWidth ||
+        oldDelegate.colorSaturation != colorSaturation ||
+        oldDelegate.colorValue != colorValue;
   }
 }
 
@@ -619,9 +616,8 @@ class _WheelThumbPainter extends CustomPainter {
 
   @override
   bool shouldRepaint(_WheelThumbPainter oldDelegate) {
-    return
-      oldDelegate.wheelWidth != wheelWidth ||
-          oldDelegate.colorHue != colorHue;
+    return oldDelegate.wheelWidth != wheelWidth ||
+        oldDelegate.colorHue != colorHue;
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flex_color_picker
 description: A customizable Flutter primary, accent and custom color picker. Includes an optional HSV wheel color picker.
-version: 2.1.1
+version: 2.1.2
 homepage: https://github.com/rydmike/flex_color_picker
 
 environment:


### PR DESCRIPTION
Thank you for creating this color picker! It does everything I need and then some. 😊

I did improve the performance of the wheel picker some by splitting it up into separate `CustomPainter` widgets and introducing `RepaintBoundary` widgets around the more expensive painters. I also improved the `shouldRepaint` implementations for each custom painter widget so as to only repaint when relevant changes have happened.

The improvement I got was from ~18.5 FPS previously to ~120 FPS after changes in profile mode on my test device (mid-range Android phone from 2019.)