### PR TITLE
fix effectiveIconTheme.size null safe error

### DIFF
--- a/lib/src/widgets/color_picker_toolbar.dart
+++ b/lib/src/widgets/color_picker_toolbar.dart
@@ -73,12 +73,9 @@ class ColorPickerToolbar extends StatelessWidget {
         pasteKeyTooltip = platformControlKey(platform, 'V');
       }
       // Make the Copy, Paste, OK and close tooltips.
-      copyTooltip =
-          (copyPasteBehavior.copyTooltip ?? translate.copyButtonLabel) +
-              copyKeyTooltip;
+      copyTooltip = (copyPasteBehavior.copyTooltip ?? translate.copyButtonLabel) + copyKeyTooltip;
       pasteTooltip =
-          (copyPasteBehavior.pasteTooltip ?? translate.pasteButtonLabel) +
-              pasteKeyTooltip;
+          (copyPasteBehavior.pasteTooltip ?? translate.pasteButtonLabel) + pasteKeyTooltip;
       okTooltip = toolIcons.okTooltip ?? translate.okButtonLabel;
       closeTooltip = toolIcons.closeTooltip ??
           (toolIcons.closeTooltipIsClose
@@ -88,11 +85,12 @@ class ColorPickerToolbar extends StatelessWidget {
     // Get current theme and passed in icon theme.
     final ThemeData theme = Theme.of(context);
     final IconThemeData? iconTheme = toolIcons.toolIconsThemeData;
+    final double fixedIconSize = iconTheme?.size ?? 22;
     // This is a merge of provided iconThemeData, with
     // fallback to default values, color has no default, remains as null.
     final IconThemeData effectiveIconTheme = theme.iconTheme.copyWith(
       color: iconTheme?.color,
-      size: iconTheme?.size ?? 22,
+      size: fixedIconSize,
       opacity: iconTheme?.opacity ?? 0.90,
     );
     return Theme(
@@ -100,17 +98,13 @@ class ColorPickerToolbar extends StatelessWidget {
       child: Row(
         children: <Widget>[
           if (title != null) title!,
-          if (title != null ||
-              onCopy != null ||
-              onPaste != null ||
-              onOk != null ||
-              onClose != null)
+          if (title != null || onCopy != null || onPaste != null || onOk != null || onClose != null)
             const Spacer(),
           if (onCopy != null)
             IconButton(
               icon: Icon(copyPasteBehavior.copyIcon),
               onPressed: onCopy,
-              iconSize: effectiveIconTheme.size,
+              iconSize: fixedIconSize,
               visualDensity: toolIcons.visualDensity,
               padding: toolIcons.padding,
               alignment: toolIcons.alignment,
@@ -122,7 +116,7 @@ class ColorPickerToolbar extends StatelessWidget {
             IconButton(
               icon: Icon(copyPasteBehavior.pasteIcon),
               onPressed: onPaste,
-              iconSize: effectiveIconTheme.size,
+              iconSize: fixedIconSize,
               visualDensity: toolIcons.visualDensity,
               padding: toolIcons.padding,
               alignment: toolIcons.alignment,
@@ -134,7 +128,7 @@ class ColorPickerToolbar extends StatelessWidget {
             IconButton(
               icon: Icon(toolIcons.closeIcon),
               onPressed: onClose,
-              iconSize: effectiveIconTheme.size,
+              iconSize: fixedIconSize,
               visualDensity: toolIcons.visualDensity,
               padding: toolIcons.padding,
               alignment: toolIcons.alignment,
@@ -146,7 +140,7 @@ class ColorPickerToolbar extends StatelessWidget {
             IconButton(
               icon: Icon(toolIcons.okIcon),
               onPressed: onOk,
-              iconSize: effectiveIconTheme.size,
+              iconSize: fixedIconSize,
               visualDensity: toolIcons.visualDensity,
               padding: toolIcons.padding,
               alignment: toolIcons.alignment,
@@ -158,7 +152,7 @@ class ColorPickerToolbar extends StatelessWidget {
             IconButton(
               icon: Icon(toolIcons.closeIcon),
               onPressed: onClose,
-              iconSize: effectiveIconTheme.size,
+              iconSize: fixedIconSize,
               visualDensity: toolIcons.visualDensity,
               padding: toolIcons.padding,
               alignment: toolIcons.alignment,


### PR DESCRIPTION
#40 The argument type 'double?' can't be assigned to the parameter type 'double' because 'double?' is nullable and 'double' isn't. iconSize: effectiveIconTheme.size
