### PR TITLE
fix show correct height when widget showing in a dialog.

### DIFF
--- a/lib/src/color_picker.dart
+++ b/lib/src/color_picker.dart
@@ -1781,6 +1781,7 @@ class _ColorPickerState extends State<ColorPicker> {
       child: Padding(
         padding: widget.padding,
         child: Column(
+          mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: widget.crossAxisAlignment,
           children: <Widget>[
             // Show title bar widget if we have one.


### PR DESCRIPTION
It will take up all of the screen height when didn't set up on the windows platform.