### PR TITLE
Migrate Flutter Material and Cupertino imports to decoupled UI packages

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -53,6 +53,13 @@ analyzer:
     - "test/.test_coverage.dart"
     - "bin/cache/**"
     - "lib/generated_plugin_registrant.dart"
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 
   # For more information see: https://dart.dev/tools/analysis
   language:

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -1,3 +1,12 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: ../analysis_options.yaml
 
 linter:

--- a/example/lib/demo/main.dart
+++ b/example/lib/demo/main.dart
@@ -1,6 +1,6 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive_ce/hive.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'conditionals/dart_io_conditional.dart' as folder;
 import 'pods/pods.dart';

--- a/example/lib/demo/pods/pods.dart
+++ b/example/lib/demo/pods/pods.dart
@@ -1,6 +1,6 @@
 import 'package:flex_color_picker/flex_color_picker.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../store/hive_store.dart';
 import '../utils/keys.dart';

--- a/example/lib/demo/pods/pods_reset.dart
+++ b/example/lib/demo/pods/pods_reset.dart
@@ -1,6 +1,6 @@
 import 'package:flex_color_picker/flex_color_picker.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../utils/keys.dart';
 import 'pods.dart';

--- a/example/lib/demo/screens/color_picker/about.dart
+++ b/example/lib/demo/screens/color_picker/about.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../utils/app.dart';

--- a/example/lib/demo/screens/color_picker/color_picker_card.dart
+++ b/example/lib/demo/screens/color_picker/color_picker_card.dart
@@ -1,6 +1,6 @@
 import 'package:flex_color_picker/flex_color_picker.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../pods/pods.dart';
 import '../../utils/app.dart';

--- a/example/lib/demo/screens/color_picker/color_picker_dialog.dart
+++ b/example/lib/demo/screens/color_picker/color_picker_dialog.dart
@@ -1,6 +1,6 @@
 import 'package:flex_color_picker/flex_color_picker.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../pods/pods.dart';
 import '../../utils/app.dart';

--- a/example/lib/demo/screens/color_picker/color_picker_screen.dart
+++ b/example/lib/demo/screens/color_picker/color_picker_screen.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../utils/app.dart';
 import '../../widgets/flex_app_bar.dart';

--- a/example/lib/demo/screens/color_picker/picker_indicators/card_picker_color_indicator.dart
+++ b/example/lib/demo/screens/color_picker/picker_indicators/card_picker_color_indicator.dart
@@ -1,6 +1,6 @@
 import 'package:flex_color_picker/flex_color_picker.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../utils/app.dart';

--- a/example/lib/demo/screens/color_picker/picker_indicators/dialog_picker_color_indicator.dart
+++ b/example/lib/demo/screens/color_picker/picker_indicators/dialog_picker_color_indicator.dart
@@ -1,6 +1,6 @@
 import 'package:flex_color_picker/flex_color_picker.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../utils/app.dart';

--- a/example/lib/demo/screens/color_picker/picker_indicators/meta_picker_color_indicator.dart
+++ b/example/lib/demo/screens/color_picker/picker_indicators/meta_picker_color_indicator.dart
@@ -1,6 +1,6 @@
 import 'package:flex_color_picker/flex_color_picker.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../color_picker_dialog.dart';

--- a/example/lib/demo/screens/color_picker/picker_indicators/on_changed_color_indicator.dart
+++ b/example/lib/demo/screens/color_picker/picker_indicators/on_changed_color_indicator.dart
@@ -1,6 +1,6 @@
 import 'package:flex_color_picker/flex_color_picker.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../utils/theme.dart';

--- a/example/lib/demo/screens/color_picker/picker_indicators/on_end_color_indicator.dart
+++ b/example/lib/demo/screens/color_picker/picker_indicators/on_end_color_indicator.dart
@@ -1,6 +1,6 @@
 import 'package:flex_color_picker/flex_color_picker.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../utils/theme.dart';

--- a/example/lib/demo/screens/color_picker/picker_indicators/on_start_color_indicator.dart
+++ b/example/lib/demo/screens/color_picker/picker_indicators/on_start_color_indicator.dart
@@ -1,6 +1,6 @@
 import 'package:flex_color_picker/flex_color_picker.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../utils/theme.dart';

--- a/example/lib/demo/screens/color_picker/picker_indicators/premade_dialog_picker_color_indicator.dart
+++ b/example/lib/demo/screens/color_picker/picker_indicators/premade_dialog_picker_color_indicator.dart
@@ -1,6 +1,6 @@
 import 'package:flex_color_picker/flex_color_picker.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../utils/app.dart';

--- a/example/lib/demo/screens/color_picker/picker_sliders/border_radius_slider.dart
+++ b/example/lib/demo/screens/color_picker/picker_sliders/border_radius_slider.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/maybe_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_sliders/column_spacing_slider.dart
+++ b/example/lib/demo/screens/color_picker/picker_sliders/column_spacing_slider.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/maybe_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_sliders/elevation_slider.dart
+++ b/example/lib/demo/screens/color_picker/picker_sliders/elevation_slider.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/maybe_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_sliders/item_size_slider.dart
+++ b/example/lib/demo/screens/color_picker/picker_sliders/item_size_slider.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/maybe_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_sliders/opacity_thumb_radius_slider.dart
+++ b/example/lib/demo/screens/color_picker/picker_sliders/opacity_thumb_radius_slider.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/maybe_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_sliders/opacity_track_height_slider.dart
+++ b/example/lib/demo/screens/color_picker/picker_sliders/opacity_track_height_slider.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/maybe_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_sliders/opacity_track_width_slider.dart
+++ b/example/lib/demo/screens/color_picker/picker_sliders/opacity_track_width_slider.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/maybe_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_sliders/padding_slider.dart
+++ b/example/lib/demo/screens/color_picker/picker_sliders/padding_slider.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/maybe_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_sliders/run_spacing_slider.dart
+++ b/example/lib/demo/screens/color_picker/picker_sliders/run_spacing_slider.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/maybe_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_sliders/spacing_slider.dart
+++ b/example/lib/demo/screens/color_picker/picker_sliders/spacing_slider.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/maybe_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_sliders/wheel_diameter_slider.dart
+++ b/example/lib/demo/screens/color_picker/picker_sliders/wheel_diameter_slider.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/maybe_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_sliders/wheel_square_border_radius_slider.dart
+++ b/example/lib/demo/screens/color_picker/picker_sliders/wheel_square_border_radius_slider.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/maybe_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_sliders/wheel_square_padding_slider.dart
+++ b/example/lib/demo/screens/color_picker/picker_sliders/wheel_square_padding_slider.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/maybe_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_sliders/wheel_width_slider.dart
+++ b/example/lib/demo/screens/color_picker/picker_sliders/wheel_width_slider.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/maybe_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/close_button_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/close_button_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/close_is_last_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/close_is_last_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/color_code_focus_no_color_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/color_code_focus_no_color_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/color_code_has_color_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/color_code_has_color_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/color_code_read_only_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/color_code_read_only_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/color_code_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/color_code_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/color_edit_icon_button_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/color_edit_icon_button_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/color_name_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/color_name_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/color_value_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/color_value_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/control_copy_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/control_copy_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/control_paste_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/control_paste_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/dialog_action_buttons_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/dialog_action_buttons_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/dialog_action_icons_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/dialog_action_icons_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/dialog_action_only_ok_button_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/dialog_action_only_ok_button_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/edit_field_copy_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/edit_field_copy_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/edit_uses_parsed_paste_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/edit_uses_parsed_paste_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/enable_tooltips_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/enable_tooltips_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/feedback_parse_error_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/feedback_parse_error_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/has_border_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/has_border_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/heading_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/heading_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/index850_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/index850_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/long_press_menu_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/long_press_menu_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/material_name_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/material_name_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/ok_button_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/ok_button_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/opacity_subheading_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/opacity_subheading_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/opacity_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/opacity_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/parse_short_hex_code_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/parse_short_hex_code_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/picker_auto_focus_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/picker_auto_focus_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/recent_colors_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/recent_colors_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/recent_subheading_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/recent_subheading_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/secondary_desktop_long_device_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/secondary_desktop_long_device_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/secondary_desktop_long_web_device_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/secondary_desktop_long_web_device_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/secondary_menu_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/secondary_menu_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/shades_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/shades_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/snackbar_parse_error_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/snackbar_parse_error_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/subheading_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/subheading_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/title_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/title_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/tonal_legacy_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/tonal_legacy_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/tonal_same_size_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/tonal_same_size_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/tonal_subheading_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/tonal_subheading_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/tonal_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/tonal_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/toolbar_copy_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/toolbar_copy_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/toolbar_paste_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/toolbar_paste_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_switches/wheel_has_border_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_switches/wheel_has_border_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/switch_tile_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_text_fields/text_field_focus_demo.dart
+++ b/example/lib/demo/screens/color_picker/picker_text_fields/text_field_focus_demo.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class TextFieldFocusDemo extends StatefulWidget {
   const TextFieldFocusDemo({super.key});

--- a/example/lib/demo/screens/color_picker/picker_toggle_buttons/actions_order_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_toggle_buttons/actions_order_switch.dart
@@ -1,6 +1,6 @@
 import 'package:flex_color_picker/flex_color_picker.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/maybe_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_toggle_buttons/alignment_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_toggle_buttons/alignment_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/maybe_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_toggle_buttons/copy_format_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_toggle_buttons/copy_format_switch.dart
@@ -1,6 +1,6 @@
 import 'package:flex_color_picker/flex_color_picker.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/maybe_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_toggle_buttons/pickers_enabled_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_toggle_buttons/pickers_enabled_switch.dart
@@ -1,6 +1,6 @@
 import 'package:flex_color_picker/flex_color_picker.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 import '../../../widgets/maybe_tooltip.dart';

--- a/example/lib/demo/screens/color_picker/picker_toggle_buttons/theme_mode_switch.dart
+++ b/example/lib/demo/screens/color_picker/picker_toggle_buttons/theme_mode_switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../pods/pods.dart';
 

--- a/example/lib/demo/screens/home/home_screen.dart
+++ b/example/lib/demo/screens/home/home_screen.dart
@@ -1,8 +1,6 @@
-import 'dart:async';
-
 import 'package:flex_color_picker/flex_color_picker.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../utils/app.dart';
 import '../../utils/theme.dart';
@@ -124,13 +122,13 @@ class HomeScreen extends StatelessWidget {
 
             OutlinedButton(
               onPressed: () {
-                unawaited(Navigator.push<Object>(
+                Navigator.push<Object>(
                   context,
                   MaterialPageRoute<Object>(
                     builder: (BuildContext context) =>
                         const ColorPickerScreen(),
                   ),
-                ));
+                );
               },
               child: Padding(
                 padding: const EdgeInsets.all(7),

--- a/example/lib/demo/screens/home/reset_settings_button.dart
+++ b/example/lib/demo/screens/home/reset_settings_button.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../pods/pods_reset.dart';
 import '../../widgets/platform_alert_dialog.dart';

--- a/example/lib/demo/store/hive_store.dart
+++ b/example/lib/demo/store/hive_store.dart
@@ -1,6 +1,6 @@
 import 'package:flex_color_picker/flex_color_picker.dart';
-import 'package:flutter/material.dart';
 import 'package:hive_ce/hive.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Hive box name, used for the Hive box that store all settings.
 const String kHiveBox = 'picker_settings';

--- a/example/lib/demo/utils/app.dart
+++ b/example/lib/demo/utils/app.dart
@@ -1,7 +1,7 @@
 import 'package:flex_color_picker/flex_color_picker.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// Contains used constants for doubles, strings and colors.
 class App {

--- a/example/lib/demo/utils/app_scroll_behavior.dart
+++ b/example/lib/demo/utils/app_scroll_behavior.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// Custom app scroll behavior class.
 ///

--- a/example/lib/demo/utils/color_extensions.dart
+++ b/example/lib/demo/utils/color_extensions.dart
@@ -1,6 +1,6 @@
 import 'dart:math' as math;
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// Extension methods that mimic some of TinyColor's functions
 /// https://pub.dev/packages/tinycolor

--- a/example/lib/demo/utils/keys.dart
+++ b/example/lib/demo/utils/keys.dart
@@ -1,5 +1,5 @@
 import 'package:flex_color_picker/flex_color_picker.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// Key constants for key-value pairs for storing the settings as well
 /// as a map with default value for each key-value pair settings.

--- a/example/lib/demo/utils/theme.dart
+++ b/example/lib/demo/utils/theme.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'app.dart';
 

--- a/example/lib/demo/widgets/flex_app_bar.dart
+++ b/example/lib/demo/widgets/flex_app_bar.dart
@@ -1,7 +1,7 @@
 import 'dart:ui';
 
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../utils/color_extensions.dart';
 import 'if_wrapper.dart';

--- a/example/lib/demo/widgets/if_wrapper.dart
+++ b/example/lib/demo/widgets/if_wrapper.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// Type definition for a builder function used by IfWrapper.
 typedef IfWrapBuilder = Widget Function(BuildContext context, Widget child);

--- a/example/lib/demo/widgets/maybe_tooltip.dart
+++ b/example/lib/demo/widgets/maybe_tooltip.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// Wrap the [child] with a [Tooltip] if [condition] is true and [tooltip] is
 /// not null and [tooltip] is not empty, otherwise just return the [child].

--- a/example/lib/demo/widgets/platform_alert_dialog.dart
+++ b/example/lib/demo/widgets/platform_alert_dialog.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'platform_widget.dart';
 

--- a/example/lib/demo/widgets/platform_widget.dart
+++ b/example/lib/demo/widgets/platform_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// An abstraction to build platform adaptive Widgets.
 abstract class PlatformWidget extends StatelessWidget {

--- a/example/lib/demo/widgets/switch_list_tile_adaptive.dart
+++ b/example/lib/demo/widgets/switch_list_tile_adaptive.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// A theme following wrapper for [SwitchListTileAdaptive].
 ///

--- a/example/lib/demo/widgets/switch_tile_tooltip.dart
+++ b/example/lib/demo/widgets/switch_tile_tooltip.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'maybe_tooltip.dart';
 import 'switch_list_tile_adaptive.dart';

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flex_color_picker/flex_color_picker.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'demo/utils/app_scroll_behavior.dart';
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -97,6 +97,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.5"
+  cupertino_ui:
+    dependency: "direct main"
+    description:
+      name: cupertino_ui
+      sha256: "7ed8ce4159d342eec4c65f4ea6eec57adaf9365404378541f38efc1da20a5b3d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   fake_async:
     dependency: transitive
     description:
@@ -138,6 +146,11 @@ packages:
     version: "4.0.1"
   flutter:
     dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_localizations:
+    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -215,6 +228,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.3"
   io:
     dependency: transitive
     description:
@@ -287,6 +308,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.13.0"
+  material_ui:
+    dependency: "direct main"
+    description:
+      name: material_ui
+      sha256: d9b4f6c69b80bc83d0a14357c86e4c14c8076e807ae73cf2960c8560f623995f
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   meta:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: da0d9209ca76bde579f2da330aeb9df62b6319c834fa7baae052021b0462401f
+      sha256: "1b0e6a07425a3e460666e88bf1c949ccc7bb0116ad562ce94a1eca60fe820725"
       url: "https://pub.dev"
     source: hosted
-    version: "85.0.0"
+    version: "103.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "974859dc0ff5f37bc4313244b3218c791810d03ab3470a579580279ba971a48d"
+      sha256: "61c04d0c1bfed555c681ea079519933f071a5a026578ff73c4ff0df2d3462e5e"
       url: "https://pub.dev"
     source: hosted
-    version: "7.7.1"
+    version: "13.3.0"
   args:
     dependency: transitive
     description:
@@ -45,10 +45,18 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
+  cli_config:
+    dependency: transitive
+    description:
+      name: cli_config
+      sha256: ac20a183a07002b700f0c25e61b7ee46b23c309d76ab7b7640a028f18e4d99ec
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   clock:
     dependency: transitive
     description:
@@ -77,10 +85,10 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: c1fb2dce3c0085f39dc72668e85f8e0210ec7de05345821ff58530567df345a5
+      sha256: "956a3de0725ca232ad353565a8290d3357592bf4250f6f298a185e2d949c5d3d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.2"
+    version: "1.15.1"
   crypto:
     dependency: transitive
     description:
@@ -223,14 +231,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.2+1"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.1"
   json_annotation:
     dependency: transitive
     description:
@@ -275,26 +275,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:
@@ -520,26 +520,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      sha256: ca578dc12bb8b2f40b67b7d3bd2fac4f31c01a6ff7130a14e2597b919934507f
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.3"
+    version: "1.31.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.12"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: d2e98ec12998368dc59ddd47ab709f2cd55acd6b66dc7db764455a44082f4bc5
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.18"
   typed_data:
     dependency: transitive
     description:
@@ -616,10 +616,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   vm_service:
     dependency: transitive
     description:
@@ -680,10 +680,10 @@ packages:
     dependency: transitive
     description:
       name: yaml
-      sha256: "75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5"
+      sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.3"
 sdks:
-  dart: ">=3.8.0-0 <4.0.0"
-  flutter: ">=3.38.0"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -30,6 +30,8 @@ dependencies:
   # Used for launching a WEB URL (by Google flutter.dev).
   url_launcher: ^6.3.2
 
+  material_ui: any
+  cupertino_ui: any
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/lib/src/color_indicator.dart
+++ b/lib/src/color_indicator.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// A Material widget used as a color indicator and color selector by the
 /// FlexColorPicker package's `ColorPicker` widget.

--- a/lib/src/color_picker.dart
+++ b/lib/src/color_picker.dart
@@ -1,9 +1,11 @@
 import 'dart:async';
 
-import 'package:flutter/cupertino.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart' show SemanticsConfiguration;
+import 'package:flutter/semantics.dart' show SemanticsConfiguration;
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'color_indicator.dart';
 import 'color_picker_extensions.dart';

--- a/lib/src/color_picker_extensions.dart
+++ b/lib/src/color_picker_extensions.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'color_tools.dart';
 

--- a/lib/src/color_tools.dart
+++ b/lib/src/color_tools.dart
@@ -1,6 +1,6 @@
 import 'dart:math' as math;
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'functions/picker_functions.dart';
 

--- a/lib/src/color_wheel_picker.dart
+++ b/lib/src/color_wheel_picker.dart
@@ -2,7 +2,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Set the bool flag to true to show debug prints. Even if it is forgotten
 // to set it to false, debug prints will not show in release builds.

--- a/lib/src/functions/picker_functions.dart
+++ b/lib/src/functions/picker_functions.dart
@@ -1,7 +1,7 @@
 import 'dart:math' as math;
 
 import 'package:flex_seed_scheme/flex_seed_scheme.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../models/color_picker_type.dart';
 

--- a/lib/src/models/color_picker_action_buttons.dart
+++ b/lib/src/models/color_picker_action_buttons.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// Type of button used for OK or Cancel action button on a FlexColorPicker
 /// dialog.

--- a/lib/src/models/color_picker_copy_paste_behavior.dart
+++ b/lib/src/models/color_picker_copy_paste_behavior.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// Enum that controls the RGB string format of the copied color value.
 ///

--- a/lib/src/universal_widgets/context_popup_menu.dart
+++ b/lib/src/universal_widgets/context_popup_menu.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../functions/picker_functions.dart';
 
@@ -35,14 +35,14 @@ class ContextPopupMenu<T> extends StatefulWidget {
   const ContextPopupMenu({
     super.key,
     required this.items,
-    required ValueChanged<T?> onSelected,
+    required ValueChanged<T?> this._onSelected,
     this.onOpen,
     required this.child,
     this.useLongPress = false,
     this.useSecondaryTapDown = false,
     this.useSecondaryOnDesktopLongOnDevice = false,
     this.useSecondaryOnDesktopLongOnDeviceAndWeb = true,
-  }) : _onSelected = onSelected;
+  });
 
   /// The popup menu entries for the long press menu.
   final List<PopupMenuEntry<T>> items;

--- a/lib/src/universal_widgets/dry_intrinsic.dart
+++ b/lib/src/universal_widgets/dry_intrinsic.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:material_ui/material_ui.dart';
 
 // These two classes are a workaround to issue:
 // https://github.com/flutter/flutter/issues/71687

--- a/lib/src/universal_widgets/if_wrapper.dart
+++ b/lib/src/universal_widgets/if_wrapper.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// A potential Widget builder function.
 typedef IfWrapBuilder = Widget Function(BuildContext context, Widget child);

--- a/lib/src/widgets/color_code_field.dart
+++ b/lib/src/widgets/color_code_field.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../color_picker_extensions.dart';
 import '../functions/picker_functions.dart';

--- a/lib/src/widgets/color_picker_toolbar.dart
+++ b/lib/src/widgets/color_picker_toolbar.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../functions/picker_functions.dart';
 import '../models/color_picker_action_buttons.dart';

--- a/lib/src/widgets/context_copy_paste_menu.dart
+++ b/lib/src/widgets/context_copy_paste_menu.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../universal_widgets/context_popup_menu.dart';
 

--- a/lib/src/widgets/copy_paste_handler.dart
+++ b/lib/src/widgets/copy_paste_handler.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../universal_widgets/if_wrapper.dart';
 import 'context_copy_paste_menu.dart';

--- a/lib/src/widgets/main_colors.dart
+++ b/lib/src/widgets/main_colors.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../flex_color_picker.dart';
 

--- a/lib/src/widgets/opacity/opacity_slider.dart
+++ b/lib/src/widgets/opacity/opacity_slider.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:ui' as ui;
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'opacity_slider_thumb.dart';
 import 'opacity_slider_track.dart';

--- a/lib/src/widgets/opacity/opacity_slider_thumb.dart
+++ b/lib/src/widgets/opacity/opacity_slider_thumb.dart
@@ -1,6 +1,6 @@
 import 'dart:math';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// The [OpacitySliderThumb] is a custom version of [RoundSliderThumbShape]
 /// that draws a circle as thumb, with [color] as color inside the thumb.

--- a/lib/src/widgets/opacity/opacity_slider_track.dart
+++ b/lib/src/widgets/opacity/opacity_slider_track.dart
@@ -1,7 +1,7 @@
 import 'dart:math' as math;
 import 'dart:ui' as ui;
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// A custom slider track for the opacity slider.
 ///

--- a/lib/src/widgets/picker_selector.dart
+++ b/lib/src/widgets/picker_selector.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../models/color_picker_type.dart';
 
@@ -48,11 +48,13 @@ class SelectPicker extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // Set default text style for the segmented slider control.
-    final TextStyle segmentTextStyle = textStyle ??
+    final TextStyle segmentTextStyle =
+        textStyle ??
         Theme.of(context).textTheme.bodySmall ??
         const TextStyle(fontSize: 12);
 
-    final Color effectiveThumbColor = thumbColor ??
+    final Color effectiveThumbColor =
+        thumbColor ??
         const CupertinoDynamicColor.withBrightness(
           color: Color(0xFFFFFFFF),
           darkColor: Color(0xFF636366),
@@ -61,9 +63,9 @@ class SelectPicker extends StatelessWidget {
     final Color? effectiveThumbOnColor = thumbColor == null
         ? null
         : ThemeData.estimateBrightnessForColor(effectiveThumbColor) ==
-                Brightness.light
-            ? Colors.black
-            : Colors.white;
+              Brightness.light
+        ? Colors.black
+        : Colors.white;
 
     return SizedBox(
       width: double.infinity,
@@ -149,7 +151,8 @@ class SelectPicker extends StatelessWidget {
                 ),
               ),
           },
-          thumbColor: thumbColor ??
+          thumbColor:
+              thumbColor ??
               const CupertinoDynamicColor.withBrightness(
                 color: Color(0xFFFFFFFF),
                 darkColor: Color(0xFF636366),

--- a/lib/src/widgets/recent_colors.dart
+++ b/lib/src/widgets/recent_colors.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../flex_color_picker.dart';
 

--- a/lib/src/widgets/shade_colors.dart
+++ b/lib/src/widgets/shade_colors.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../flex_color_picker.dart';
 import '../functions/picker_functions.dart';

--- a/lib/src/widgets/tonal_palette_colors.dart
+++ b/lib/src/widgets/tonal_palette_colors.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../flex_color_picker.dart';
 import '../functions/picker_functions.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -97,6 +97,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.5"
+  cupertino_ui:
+    dependency: "direct main"
+    description:
+      name: cupertino_ui
+      sha256: "7ed8ce4159d342eec4c65f4ea6eec57adaf9365404378541f38efc1da20a5b3d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   dispose_scope:
     dependency: transitive
     description:
@@ -142,6 +150,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_localizations:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -179,6 +192,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.3"
   io:
     dependency: transitive
     description:
@@ -243,6 +264,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.13.0"
+  material_ui:
+    dependency: "direct main"
+    description:
+      name: material_ui
+      sha256: d9b4f6c69b80bc83d0a14357c86e4c14c8076e807ae73cf2960c8560f623995f
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   meta:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: da0d9209ca76bde579f2da330aeb9df62b6319c834fa7baae052021b0462401f
+      sha256: "1b0e6a07425a3e460666e88bf1c949ccc7bb0116ad562ce94a1eca60fe820725"
       url: "https://pub.dev"
     source: hosted
-    version: "85.0.0"
+    version: "103.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "974859dc0ff5f37bc4313244b3218c791810d03ab3470a579580279ba971a48d"
+      sha256: "61c04d0c1bfed555c681ea079519933f071a5a026578ff73c4ff0df2d3462e5e"
       url: "https://pub.dev"
     source: hosted
-    version: "7.7.1"
+    version: "13.3.0"
   args:
     dependency: transitive
     description:
@@ -45,10 +45,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   cli_config:
     dependency: transitive
     description:
@@ -187,14 +187,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.1"
   json_annotation:
     dependency: transitive
     description:
@@ -239,26 +231,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:
@@ -420,26 +412,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      sha256: ca578dc12bb8b2f40b67b7d3bd2fac4f31c01a6ff7130a14e2597b919934507f
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.3"
+    version: "1.31.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.12"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: d2e98ec12998368dc59ddd47ab709f2cd55acd6b66dc7db764455a44082f4bc5
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.18"
   typed_data:
     dependency: transitive
     description:
@@ -452,10 +444,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   vm_service:
     dependency: transitive
     description:
@@ -513,5 +505,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
-  flutter: ">=3.38.0"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,8 +24,8 @@ topics:
   - rgb
 
 environment:
-  sdk: '>=3.6.0 <4.0.0'
-  flutter: '>=3.38.0'
+  sdk: ^3.12.0
+  flutter: ">=3.44.0"
 
 dependencies:
   # FlexSeedScheme package, by Mike Rydstrom, rydmike.com (@rydmike).
@@ -34,6 +34,8 @@ dependencies:
 
   flutter:
     sdk: flutter
+  material_ui: ^1.0.0
+  cupertino_ui: ^1.0.0
 
 dev_dependencies:
   collection:

--- a/test/color_code_field_test.dart
+++ b/test/color_code_field_test.dart
@@ -1,7 +1,7 @@
 import 'package:flex_color_picker/flex_color_picker.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'clipboard_utils.dart';
 

--- a/test/color_indicator_test.dart
+++ b/test/color_indicator_test.dart
@@ -1,7 +1,7 @@
 import 'package:flex_color_picker/src/color_indicator.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 //****************************************************************************
 // FlexColorPicker ColorIndicator Widget tests

--- a/test/color_picker_action_buttons_test.dart
+++ b/test/color_picker_action_buttons_test.dart
@@ -1,6 +1,6 @@
 import 'package:flex_color_picker/src/models/color_picker_action_buttons.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   //****************************************************************************

--- a/test/color_picker_copy_paste_behavior_test.dart
+++ b/test/color_picker_copy_paste_behavior_test.dart
@@ -1,6 +1,6 @@
 import 'package:flex_color_picker/flex_color_picker.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   //****************************************************************************

--- a/test/color_picker_patrol_test.dart
+++ b/test/color_picker_patrol_test.dart
@@ -3,9 +3,9 @@ import 'package:flex_color_picker/src/widgets/color_picker_toolbar.dart';
 import 'package:flex_color_picker/src/widgets/opacity/opacity_slider.dart';
 import 'package:flex_color_picker/src/widgets/recent_colors.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:patrol_finders/patrol_finders.dart';
 
 import 'clipboard_utils.dart';

--- a/test/color_picker_test.dart
+++ b/test/color_picker_test.dart
@@ -1,7 +1,7 @@
 import 'package:flex_color_picker/flex_color_picker.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 // ignore_for_file: unnecessary_null_comparison, for clarity in tests.
 // ignore_for_file: unused_local_variable, Calude's test, we will fix later.

--- a/test/color_wheel_picker_basic_test.dart
+++ b/test/color_wheel_picker_basic_test.dart
@@ -1,7 +1,7 @@
 import 'package:flex_color_picker/flex_color_picker.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 // ignore_for_file: unnecessary_null_comparison, for clarity in tests.
 

--- a/test/color_wheel_picker_test.dart
+++ b/test/color_wheel_picker_test.dart
@@ -1,6 +1,6 @@
 import 'package:flex_color_picker/flex_color_picker.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 // ignore_for_file: unused_local_variable, Claude added not used vars, fix later
 

--- a/test/context_popup_menu_test.dart
+++ b/test/context_popup_menu_test.dart
@@ -1,7 +1,7 @@
 import 'package:flex_color_picker/src/universal_widgets/context_popup_menu.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   testWidgets('ContextPopupMenu platform and property test',

--- a/test/copy_paste_handler_test.dart
+++ b/test/copy_paste_handler_test.dart
@@ -1,7 +1,7 @@
 import 'package:flex_color_picker/src/widgets/copy_paste_handler.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   testWidgets('CPH1: CopyPasteHandler Widget Test',

--- a/test/dry_intrinsic_test.dart
+++ b/test/dry_intrinsic_test.dart
@@ -1,8 +1,8 @@
 import 'package:flex_color_picker/src/universal_widgets/dry_intrinsic.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 //****************************************************************************
 // FlexColorPicker DryIntrinsicWidth and Height Widget tests

--- a/test/flex_color_extensions_test.dart
+++ b/test/flex_color_extensions_test.dart
@@ -1,6 +1,6 @@
 import 'package:flex_color_picker/flex_color_picker.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 // ignore_for_file: unnecessary_nullable_for_final_variable_declarations, tests.
 

--- a/test/flex_color_picker_color_extensions_test.dart
+++ b/test/flex_color_picker_color_extensions_test.dart
@@ -1,6 +1,6 @@
 import 'package:flex_color_picker/flex_color_picker.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   //****************************************************************************

--- a/test/flex_color_tools_test.dart
+++ b/test/flex_color_tools_test.dart
@@ -1,6 +1,6 @@
 import 'package:collection/collection.dart';
 import 'package:flex_color_picker/flex_color_picker.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/test/if_wrapper_test.dart
+++ b/test/if_wrapper_test.dart
@@ -1,7 +1,7 @@
 import 'package:flex_color_picker/src/universal_widgets/if_wrapper.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 //****************************************************************************
 // FlexColorPicker IFWrapper Widget tests

--- a/test/opacity_slider_test.dart
+++ b/test/opacity_slider_test.dart
@@ -1,6 +1,6 @@
 import 'package:flex_color_picker/src/widgets/opacity/opacity_slider.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   testWidgets('OpacitySlider test', (WidgetTester tester) async {

--- a/test/opacity_slider_thumb_test.dart
+++ b/test/opacity_slider_thumb_test.dart
@@ -1,6 +1,6 @@
 import 'package:flex_color_picker/src/widgets/opacity/opacity_slider_thumb.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   testWidgets('OpacitySliderThumb test', (WidgetTester tester) async {

--- a/test/opacity_slider_track_test.dart
+++ b/test/opacity_slider_track_test.dart
@@ -2,9 +2,9 @@ import 'dart:async';
 import 'dart:ui' as ui;
 
 import 'package:flex_color_picker/src/widgets/opacity/opacity_slider_track.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   testWidgets('OpacitySliderTrack test', (WidgetTester tester) async {

--- a/test/picker_functions_test.dart
+++ b/test/picker_functions_test.dart
@@ -1,6 +1,6 @@
 import 'package:flex_color_picker/src/functions/picker_functions.dart';
 import 'package:flex_color_picker/src/models/color_picker_type.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/test/show_color_picker_dialog_test.dart
+++ b/test/show_color_picker_dialog_test.dart
@@ -1,6 +1,6 @@
 import 'package:flex_color_picker/flex_color_picker.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   testWidgets('Test showColorPickerDialog', (WidgetTester tester) async {


### PR DESCRIPTION
Fixes #97

Migration is automated using:

```patch
- import 'package:flutter/material.dart';
+ import 'package:material_ui/material_ui.dart';
```

The minimum supported SDK version has been updated to Flutter 3.44/Dart 3.12

`analysis_options.yaml` files were automatically updated by the Flutter CLI.

To try this updated version in a Flutter app:

```yaml
dependency_overrides:
  # https://github.com/rydmike/flex_color_picker/pull/98
  flex_color_picker:
    git:
      url: https://github.com/EchoEllet/flex_color_picker.git
      ref: chore/migrate-design-library-imports
```